### PR TITLE
alerts-server: Update Logback to log root exception first

### DIFF
--- a/alerts-server/conf/logback.xml
+++ b/alerts-server/conf/logback.xml
@@ -6,13 +6,13 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${application.home:-.}/logs/application.log</file>
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+            <pattern>%date [%level] from %logger in %thread - %message%n%rootException</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+            <pattern>%coloredLevel %logger{15} - %message%n%rootException{10}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Problem
#25 

Solution
change xException to rootException

Result
Logs root Exception first

