### PR TITLE
fixed e-mail alert by new currencies (issue #12)

### DIFF
--- a/alerts-server/app/com/alexitc/coinalerts/services/EmailMessagesProvider.scala
+++ b/alerts-server/app/com/alexitc/coinalerts/services/EmailMessagesProvider.scala
@@ -43,7 +43,7 @@ class EmailMessagesProvider @Inject()(messagesApi: MessagesApi, appConfig: AppCo
   def newCurrenciesAlertText(books: List[Book])(implicit lang: Lang): EmailText = {
     val body = books
       .map { book =>
-        messagesApi("message.newCurrenciesAlert.new", book.currency.string, book.market.string)
+        messagesApi("message.newCurrenciesAlert.new", book.currency.string, book.currencyName.map(name => s" (${name.string})").getOrElse(""), book.market.string)
       }
       .mkString("\n")
 

--- a/alerts-server/conf/messages
+++ b/alerts-server/conf/messages
@@ -48,4 +48,4 @@ message.alert.priceDecreased={0} has decreased to {1} {2}
 
 email.newCurrenciesAlert.subject=There are new currencies on {0}
 email.newCurrenciesAlert.footer=Do not wait, create your next alert: {0}
-message.newCurrenciesAlert.new=Trade {0} on {1} market.
+message.newCurrenciesAlert.new=Trade {0}{1} on {2} market.

--- a/alerts-server/conf/messages.es
+++ b/alerts-server/conf/messages.es
@@ -48,4 +48,4 @@ message.alert.priceDecreased={0} a bajado a {1} {2}
 
 email.newCurrenciesAlert.subject=Nuevas monedas en {0}
 email.newCurrenciesAlert.footer=¡No esperes más!, crea una nueva alerta: {0}
-message.newCurrenciesAlert.new=Intercambia {0} en el mercado de {1}.
+message.newCurrenciesAlert.new=Intercambia {0}{1} en el mercado de {2}.


### PR DESCRIPTION
Problem: new currencies alert doesn't show the currency name (if available)

Solution: modified newCurrenciesAlertText in EmailMessagesProvider.scala so that a new parameter "currencyName" will be supported + modified messages and messages.es so that the new parameter was used in newCurrenciesAlert message

